### PR TITLE
Incorrect doc - Do not call execute()

### DIFF
--- a/en/reference/query-builder.rst
+++ b/en/reference/query-builder.rst
@@ -44,8 +44,7 @@ This query is equivalent to the JCR-SQL2 query ``SELECT * FROM nt:unstructured W
     /** @var $qb QueryBuilder */
     $factory = $qb->getQOMFactory();
     $qb->from($factory->selector('nt:unstructured'))
-        ->where($factory->propertyExistence('name'))
-        ->execute();
+        ->where($factory->propertyExistence('name'));
 
     $result = $documentManager->getDocumentsByQuery($qb->getQuery());
     foreach ($result as $document) {


### PR DESCRIPTION
The doc is incorrect because calling ->execute() results into a QueryResult object.  This causes $qb->getQuery() failing to work because it's expecting a query builder instance
