### PR TITLE
Fixed UUID mapping to a document class property, with YAML configuration.

### DIFF
--- a/en/reference/association-mapping.rst
+++ b/en/reference/association-mapping.rst
@@ -126,7 +126,9 @@ id standard and is guaranteed to be unique for the whole PHPCR repository (all w
 
         MyPersistentClass:
           referenceable: true
-          uuid: uuid
+          fields:
+            uuid:
+              uuid: true
 
 .. note::
 


### PR DESCRIPTION
This pull request is to fix documentation for UUID mapping in YAML configuration, as it contains erroneous example.
See https://github.com/doctrine/phpcr-odm/issues/387 for detailed issue.
