### PR TITLE
Explain uniqueNodeType mapping as it relates to outer joins

### DIFF
--- a/en/reference/annotations-mapping.rst
+++ b/en/reference/annotations-mapping.rst
@@ -49,12 +49,16 @@ Document
 Optional attributes:
 
 -  **nodeType**: PHPCR type for this node, default ``nt:unstructured``.
--  **uniqueNodeType**: If this document uses a unique node type, set to ``true``
-   in order to support outer joins correctly; unnecessary in all other cases. See
+-  **uniqueNodeType**: If this document has a unique node type, set to ``true``
+   in order to support outer joins correctly. See
    :ref:`left outer join <_qbref_method_querybuilder_addjoinleftouter>` and
    :ref:`right outer join <_qbref_method_querybuilder_addjoinrightouter>`.
+   To register a custom node type, use the ``phpcr:node-type:register`` console
+   command (use ``help phpcr:node-type:register`` for the syntax; see :doc:`Tools <tools>`
+   for more information). To verify that documents claiming to have unique node types
+   are truly unique, use the ``doctrine:phpcr:mapping:verify-unique-node-types`` command.
 -  **repositoryClass**: Name of the repository to use for this document.
--  **versionable**: *(string)* Set to ``simple`` or ``full`` to enable versioning 
+-  **versionable**: *(string)* Set to ``simple`` or ``full`` to enable versioning
    (respectively simple or full level), ``false`` to disable versioning
    inheritance. Implies *referenceable*. Note that not every PHPCR implementation
    support this feature. See :doc:`Versioning <versioning>`.

--- a/en/reference/annotations-mapping.rst
+++ b/en/reference/annotations-mapping.rst
@@ -49,6 +49,10 @@ Document
 Optional attributes:
 
 -  **nodeType**: PHPCR type for this node, default ``nt:unstructured``.
+-  **uniqueNodeType**: If this document uses a unique node type, set to ``true``
+   in order to support outer joins correctly; unnecessary in all other cases. See
+   :ref:`left outer join <_qbref_method_querybuilder_addjoinleftouter>` and
+   :ref:`right outer join <_qbref_method_querybuilder_addjoinrightouter>`.
 -  **repositoryClass**: Name of the repository to use for this document.
 -  **versionable**: *(string)* Set to ``simple`` or ``full`` to enable versioning 
    (respectively simple or full level), ``false`` to disable versioning

--- a/en/reference/query-builder-reference.rst
+++ b/en/reference/query-builder-reference.rst
@@ -1041,8 +1041,10 @@ source as the left operand.
     ->end();
 
 
-Note that this method is currently not implemented until we can decide
-on how it should work.
+Note that for outer joins to work correctly, documents being joined to must be mapped with
+a node type that is unique to the repository workspace, and the ``uniqueNodeType`` property
+must be set to ``true`` for the document (see :ref:`<_annref_document>`). Otherwise, the join
+will behave as an inner join.
 
 **Adds**: :ref:`select <qbref_node_select>` (Select)
 
@@ -1067,8 +1069,10 @@ source as the left operand.
     ->end();
 
 
-Note that this method is currently not implemented until we can decide
-on how it should work.
+Note that for outer joins to work correctly, documents being joined to must be mapped with
+a node type that is unique to the repository workspace, and the ``uniqueNodeType`` property
+must be set to ``true`` for the document (see :ref:`<_annref_document>`). Otherwise, the join
+will behave as an inner join.
 
 **Adds**: :ref:`select <qbref_node_select>` (Select)
 


### PR DESCRIPTION
This is a companion to doctrine/phpcr-odm#667, documenting the addition of the `uniqueNodeType` property of a document, as well as how to properly configure an outer join.

The docs previously said "This is not yet implemented" for both outer joins, but that was outdated, as they were in fact implemented.